### PR TITLE
Increase transclusion line break spacing

### DIFF
--- a/src/theme.scss
+++ b/src/theme.scss
@@ -550,3 +550,10 @@ body.adwaita-icons-linux-only.mod-linux {
         @include replace-svg(var(--adwaita-icon-folder-saved-search-symbolic))
     }
 }
+
+/* Increase <br> spacing in transclusions aka ![[embeds]] */
+.internal-embed br {
+    margin: 1em 0;
+    display: block;
+    content: "";
+}


### PR DESCRIPTION
Makes line breaks in transclusions have a spacing more similar to normal line breaks.

Before:
![image](https://github.com/birneee/obsidian-adwaita-theme/assets/595711/3a0199d1-6ced-4d78-8f6e-6a882f9b9a90)

After:
![image](https://github.com/birneee/obsidian-adwaita-theme/assets/595711/68524963-09e9-4736-8c05-f68a3c18c938)

While a little opinionated, it feels *more right* to me - especially given that you can't *really* just do 2 newlines as that would then break the ability to transclude since that's how `^block-id`s in markdown work.

Try it out and let me know your thoughts. I've been using it for a while, it works really well for me.