### PR TITLE
Updated `adw_icon_theme_repo` branch path in `justfile`

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 main:
     just css
 
-adw_icon_theme_repo := "https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/raw/43/Adwaita/scalable"
+adw_icon_theme_repo := "https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/tree/master/Adwaita/symbolic"
 adw_icon_download_dir := "./build/adw-icons"
 
 adw-icons:

--- a/justfile
+++ b/justfile
@@ -1,7 +1,7 @@
 main:
     just css
 
-adw_icon_theme_repo := "https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/tree/master/Adwaita/symbolic"
+adw_icon_theme_repo := "https://gitlab.gnome.org/GNOME/adwaita-icon-theme/-/raw/master/Adwaita/symbolic"
 adw_icon_download_dir := "./build/adw-icons"
 
 adw-icons:


### PR DESCRIPTION
The `adwaita-icon-theme` branch doesn't exist anymore, so the `justfile` script might not work anymore. Might be better to pull straight from `master` (don't be alarmed by the `symbolic` suffix, I confirmed all icons were moved from `scalable` at some point in the past)